### PR TITLE
Fixed a connection bug.

### DIFF
--- a/bluetooth.ios.js
+++ b/bluetooth.ios.js
@@ -376,6 +376,7 @@ Bluetooth.retrievePeripheralsWithIdentifiers = function (arg) {
       //Init an NSMutableArray(NSUUID) from the string array parameter.
       var arrayOfUUID = NSMutableArray.new();
       for (var i = 0; i < arg.UUID.length; i++){
+        if (!arg.UUID[i]) continue;
         arrayOfUUID.addObject(NSUUID.alloc().initWithUUIDString(arg.UUID[i]));
       }
 


### PR DESCRIPTION
When null was added to our peripheral array, it caused the connection code to throw errors. This is the fix.